### PR TITLE
Add support for options page built using react

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This is a fork of [create-react-app](https://github.com/facebook/create-react-ap
 
 - [x] [Same CRA Developer Experience](https://github.com/facebook/create-react-app#whats-included) for your browser extension projects (~~service worker functionality~~)
 - [x] [Webpack dev server](https://github.com/webpack/webpack-dev-server) hot reloads extension on changes (NOTE: contentScript hot reloading not supported)
-- [x] [Supports any combination of background, content and popup chrome extensions](#only-1-new-convention)
+- [x] [Supports any combination of background, content, options and popup chrome extensions](#only-1-new-convention)
 - [x] [Automated fork watcher](https://github.com/wei/pull) to stay updated with the original CRA
 - [ ] Add support for [automated deployments](https://github.com/LinusU/wext-shipit) and docs to help users with what to do after having built their extension.
 - [ ] Add e2e test suite similar to the [original CRA](https://github.com/facebook/create-react-app/tree/master/test) and run with automated pipeline.
@@ -50,7 +50,7 @@ There are [different types of chrome extensions](https://developer.chrome.com/ex
 - [Popup UI](https://developer.chrome.com/extensions/user_interface#popup) which renders your `index.js` when you click on your extension in the browser extension icon.
 - [Background script](https://developer.chrome.com/extensions/background_pages) which will run in the background from `/background/index.js` and can be use for things like [state-management](https://github.com/tshaddix/webext-redux).
 - [Content script](https://developer.chrome.com/extensions/content_scripts) from `/contentScript/index.js` which will run on configured web pages
-- [Options UI](https://developer.chrome.com/extensions/options) :negative_squared_cross_mark: Does not support yet
+- [Options UI](https://developer.chrome.com/extensions/options) which renders your `/options/` when you click on your extension in the browser extension icon.
 - [Dev tools page](https://developer.chrome.com/extensions/devtools) :negative_squared_cross_mark: Does not support yet
 
 These are all controlled by the all important [`/public/manifest.json`](https://github.com/VasilyShelkov/create-react-extension/blob/master/packages/react-scripts/template/public/manifest.json) which is [configurable](https://developer.chrome.com/extensions/manifest) by you to control what kind of extension you want build.
@@ -102,12 +102,16 @@ my-browser-extension
 │   │   ├── icon-48.png
 │   │   ├── icon-128.png
 │   ├── popup.html
+│   ├── options.html
 │   └── manifest.json
 └── src
     ├── background
     │   ├── index.js
     ├── contentScripts
     │   ├── index.js
+    ├── options
+    │   ├── index.js
+    │   ├── Options.js
     ├── App.css
     ├── App.js
     ├── App.test.js

--- a/packages/cra-template-typescript/template/public/manifest.json
+++ b/packages/cra-template-typescript/template/public/manifest.json
@@ -22,6 +22,7 @@
     "48": "img/icon-48.png",
     "128": "img/icon-128.png"
   },
+  "options_page": "options.html",
   "permissions": ["activeTab"],
   "content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self'"
 }

--- a/packages/cra-template-typescript/template/public/options.html
+++ b/packages/cra-template-typescript/template/public/options.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="theme-color" content="#000000" />
+    <meta
+      name="description"
+      content="extension created using create-react-extension"
+    />
+    <link rel="apple-touch-icon" href="logo192.png" />
+    <!--
+      manifest.json provides metadata used when your web app is installed on a
+      user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
+    -->
+    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <!--
+      Notice the use of %PUBLIC_URL% in the tags above.
+      It will be replaced with the URL of the `public` folder during the build.
+      Only files inside the `public` folder can be referenced from the HTML.
+      Unlike "/favicon.ico" or "favicon.ico", "%PUBLIC_URL%/favicon.ico" will
+      work correctly both with client-side routing and a non-root public URL.
+      Learn how to configure a non-root public URL by running `npm run build`.
+    -->
+    <title>React App</title>
+  </head>
+  <body>
+    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <div id="options"></div>
+    <!--
+      This HTML file is a template.
+      If you open it directly in the browser, you will see an empty page.
+      You can add webfonts, meta tags, or analytics to this file.
+      The build step will place the bundled scripts into the <body> tag.
+      To begin the development, run `npm start` or `yarn start`.
+      To create a production bundle, use `npm run build` or `yarn build`.
+    -->
+  </body>
+</html>

--- a/packages/cra-template-typescript/template/src/options/Options.css
+++ b/packages/cra-template-typescript/template/src/options/Options.css
@@ -1,0 +1,43 @@
+body {
+  margin: 0;
+}
+
+.App {
+  text-align: center;
+}
+
+.App-logo {
+  height: 40vmin;
+  pointer-events: none;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .App-logo {
+    animation: App-logo-spin infinite 20s linear;
+  }
+}
+
+.App-header {
+  background-color: #282c34;
+  min-height: 100vh;
+  padding: 30px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  font-size: calc(10px + 2vmin);
+  color: white;
+}
+
+.App-link {
+  color: #61dafb;
+}
+
+@keyframes App-logo-spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/packages/cra-template-typescript/template/src/options/Options.test.tsx
+++ b/packages/cra-template-typescript/template/src/options/Options.test.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Options from './Options';
+
+test('renders learn react link', () => {
+  render(<Options />);
+  const linkElement = screen.getByText(/learn react/i);
+  expect(linkElement).toBeInTheDocument();
+});

--- a/packages/cra-template-typescript/template/src/options/Options.tsx
+++ b/packages/cra-template-typescript/template/src/options/Options.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import logo from '../logo.svg';
+import './Options.css';
+
+function Options() {
+  return (
+    <div className="App">
+      <header className="App-header">
+        <img src={logo} className="App-logo" alt="logo" />
+        <p>
+          Edit <code>src/options/Options.tsx</code> and save to reload.
+        </p>
+        <a
+          className="App-link"
+          href="https://reactjs.org"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Learn React
+        </a>
+      </header>
+    </div>
+  );
+}
+
+export default Options;

--- a/packages/cra-template-typescript/template/src/options/index.tsx
+++ b/packages/cra-template-typescript/template/src/options/index.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import Options from './Options';
+
+ReactDOM.render(
+  <React.StrictMode>
+    <Options />
+  </React.StrictMode>,
+  document.getElementById('options')
+);

--- a/packages/cra-template/template/public/manifest.json
+++ b/packages/cra-template/template/public/manifest.json
@@ -22,6 +22,7 @@
     "48": "img/icon-48.png",
     "128": "img/icon-128.png"
   },
+  "options_page": "options.html",
   "permissions": ["activeTab"],
   "content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self'"
 }

--- a/packages/cra-template/template/public/options.html
+++ b/packages/cra-template/template/public/options.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="theme-color" content="#000000" />
+    <meta
+      name="description"
+      content="extension created using create-react-extension"
+    />
+    <link rel="apple-touch-icon" href="logo192.png" />
+    <!--
+      manifest.json provides metadata used when your web app is installed on a
+      user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
+    -->
+    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <!--
+      Notice the use of %PUBLIC_URL% in the tags above.
+      It will be replaced with the URL of the `public` folder during the build.
+      Only files inside the `public` folder can be referenced from the HTML.
+
+      Unlike "/favicon.ico" or "favicon.ico", "%PUBLIC_URL%/favicon.ico" will
+      work correctly both with client-side routing and a non-root public URL.
+      Learn how to configure a non-root public URL by running `npm run build`.
+    -->
+    <title>React App</title>
+  </head>
+  <body>
+    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <div id="options"></div>
+    <!--
+      This HTML file is a template.
+      If you open it directly in the browser, you will see an empty page.
+
+      You can add webfonts, meta tags, or analytics to this file.
+      The build step will place the bundled scripts into the <body> tag.
+      
+      To begin the development, run `npm start` or `yarn start`.
+      To create a production bundle, use `npm run build` or `yarn build`.
+    -->
+  </body>
+</html>

--- a/packages/cra-template/template/src/options/Options.css
+++ b/packages/cra-template/template/src/options/Options.css
@@ -1,0 +1,43 @@
+body {
+  margin: 0;
+}
+
+.App {
+  text-align: center;
+}
+
+.App-logo {
+  height: 40vmin;
+  pointer-events: none;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .App-logo {
+    animation: App-logo-spin infinite 20s linear;
+  }
+}
+
+.App-header {
+  background-color: #282c34;
+  min-height: 100vh;
+  padding: 30px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  font-size: calc(10px + 2vmin);
+  color: white;
+}
+
+.App-link {
+  color: #61dafb;
+}
+
+@keyframes App-logo-spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/packages/cra-template/template/src/options/Options.js
+++ b/packages/cra-template/template/src/options/Options.js
@@ -1,0 +1,25 @@
+import logo from '../logo.svg';
+import './Options.css';
+
+function Options() {
+  return (
+    <div className="App">
+      <header className="App-header">
+        <img src={logo} className="App-logo" alt="logo" />
+        <p>
+          Edit <code>src/options/Options.js</code> and save to reload.
+        </p>
+        <a
+          className="App-link"
+          href="https://reactjs.org"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Learn React
+        </a>
+      </header>
+    </div>
+  );
+}
+
+export default Options;

--- a/packages/cra-template/template/src/options/Options.test.js
+++ b/packages/cra-template/template/src/options/Options.test.js
@@ -1,0 +1,9 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Options from './Options';
+
+test('renders learn react link', () => {
+  render(<Options />);
+  const linkElement = screen.getByText(/learn react/i);
+  expect(linkElement).toBeInTheDocument();
+});

--- a/packages/cra-template/template/src/options/index.js
+++ b/packages/cra-template/template/src/options/index.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import Options from './Options';
+
+ReactDOM.render(
+  <React.StrictMode>
+    <Options />
+  </React.StrictMode>,
+  document.getElementById('options')
+);

--- a/packages/react-scripts/config/paths.js
+++ b/packages/react-scripts/config/paths.js
@@ -51,10 +51,12 @@ module.exports = {
   devAppBuild: resolveApp('dev'),
   appPublic: resolveApp('public'),
   manifestJson: resolveApp('public/manifest.json'),
+  appOptionsHtml: resolveApp('public/options.html'),
   appPopupHtml: resolveApp('public/popup.html'),
   appIndexJs: resolveModule(resolveApp, 'src/index'),
   appBackgroundJs: resolveModule(resolveApp, 'src/background/index'),
   appContentScriptJs: resolveModule(resolveApp, 'src/contentScript/index'),
+  appOptionsJs: resolveModule(resolveApp, 'src/options/index'),
   appPackageJson: resolveApp('package.json'),
   appSrc: resolveApp('src'),
   appTsConfig: resolveApp('tsconfig.json'),
@@ -75,10 +77,12 @@ module.exports = {
   devAppBuild: resolveApp('dev'),
   appPublic: resolveApp('public'),
   manifestJson: resolveApp('public/manifest.json'),
+  appOptionsHtml: resolveApp('public/options.html'),
   appPopupHtml: resolveApp('public/popup.html'),
   appIndexJs: resolveModule(resolveApp, 'src/index'),
   appBackgroundJs: resolveModule(resolveApp, 'src/background/index'),
   appContentScriptJs: resolveModule(resolveApp, 'src/contentScript/index'),
+  appOptionsJs: resolveModule(resolveApp, 'src/options/index'),
   appPackageJson: resolveApp('package.json'),
   appSrc: resolveApp('src'),
   appTsConfig: resolveApp('tsconfig.json'),
@@ -113,6 +117,7 @@ if (
     appPublic: resolveOwn(`${templatePath}/public`),
     manifestJson: resolveApp(`${templatePath}/public/manifest.json`),
     appPopupHtml: resolveOwn(`${templatePath}/public/popup.html`),
+    appOptionsHtml: resolveOwn(`${templatePath}/public/options.html`),
     appIndexJs: resolveModule(resolveOwn, `${templatePath}/src/index`),
     appBackgroundJs: resolveModule(
       resolveOwn,
@@ -121,6 +126,10 @@ if (
     appContentScriptJs: resolveModule(
       resolveOwn,
       `${templatePath}/src/contentScript/index`
+    ),
+    appOptionsJs: resolveModule(
+      resolveOwn,
+      `${templatePath}/src/options/index`
     ),
     appPackageJson: resolveOwn('package.json'),
     appSrc: resolveOwn(`${templatePath}/src`),

--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -166,6 +166,12 @@ module.exports = function (webpackEnv) {
             '?http://localhost:4000',
         paths.appIndexJs,
       ].filter(Boolean),
+      options: [
+        isEnvDevelopment &&
+          require.resolve('webpack-dev-server/client') +
+            '?http://localhost:4000',
+        paths.appOptionsJs,
+      ].filter(Boolean),
       background: [
         isEnvDevelopment &&
           require.resolve('webpack-dev-server/client') +
@@ -551,6 +557,33 @@ module.exports = function (webpackEnv) {
             template: paths.appPopupHtml,
             chunks: ['app'],
             filename: 'popup.html',
+          },
+          isEnvProduction
+            ? {
+                minify: {
+                  removeComments: true,
+                  collapseWhitespace: true,
+                  removeRedundantAttributes: true,
+                  useShortDoctype: true,
+                  removeEmptyAttributes: true,
+                  removeStyleLinkTypeAttributes: true,
+                  keepClosingSlash: true,
+                  minifyJS: true,
+                  minifyCSS: true,
+                  minifyURLs: true,
+                },
+              }
+            : undefined
+        )
+      ),
+      new HtmlWebpackPlugin(
+        Object.assign(
+          {},
+          {
+            inject: true,
+            template: paths.appOptionsHtml,
+            chunks: ['options'],
+            filename: 'options.html',
           },
           isEnvProduction
             ? {

--- a/packages/react-scripts/scripts/build.js
+++ b/packages/react-scripts/scripts/build.js
@@ -63,6 +63,8 @@ if (
     paths.appIndexJs,
     paths.appBackgroundJs,
     paths.appContentScriptJs,
+    paths.appOptionsHtml,
+    paths.appOptionsJs,
   ])
 ) {
   process.exit(1);

--- a/packages/react-scripts/scripts/start.js
+++ b/packages/react-scripts/scripts/start.js
@@ -40,11 +40,8 @@ const checkRequiredFiles = require('react-dev-utils/checkRequiredFiles');
 const {
   choosePort,
   createCompiler,
-  prepareProxy,
   prepareUrls,
 } = require('react-dev-utils/WebpackDevServerUtils');
-const openBrowser = require('react-dev-utils/openBrowser');
-const semver = require('semver');
 const paths = require('../config/paths');
 const configFactory = require('../config/webpack.config');
 const createDevServerConfig = require('../config/webpackDevServer.config');
@@ -63,6 +60,8 @@ if (
     paths.appIndexJs,
     paths.appBackgroundJs,
     paths.appContentScriptJs,
+    paths.appOptionsHtml,
+    paths.appOptionsJs,
   ])
 ) {
   process.exit(1);

--- a/packages/react-scripts/scripts/utils/copyPublicFolder.js
+++ b/packages/react-scripts/scripts/utils/copyPublicFolder.js
@@ -6,7 +6,8 @@ const paths = require('../../config/paths');
 function copyPublicFolder(buildFolder) {
   fs.copySync(paths.appPublic, buildFolder, {
     dereference: true,
-    filter: file => file !== paths.appPopupHtml,
+    filter: file =>
+      file !== paths.appPopupHtml && file !== paths.appOptionsHtml,
   });
 }
 


### PR DESCRIPTION
- [x] Updated Readme
- [x] Added HTML entry point for options
- [x] Added JS entry point for options
- [x] Checks both options page related entry points in the start and build scripts
- [x] Added new options HTML entrypoints to `paths.js`   